### PR TITLE
Integrate akv_01 project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,14 @@
     <revision>0.0.1</revision>
     <sha1></sha1>
   </properties>
-  <!-- Azure functions -->
   <dependencies>
+    <!-- akv_01 -->
+    <dependency>
+      <groupId>com.teragrep</groupId>
+      <artifactId>akv_01</artifactId>
+      <version>1.0.1</version>
+    </dependency>
+    <!-- Azure functions -->
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-messaging-eventhubs</artifactId>

--- a/src/main/java/com/teragrep/aer_02/EventDataConsumer.java
+++ b/src/main/java/com/teragrep/aer_02/EventDataConsumer.java
@@ -47,8 +47,6 @@ package com.teragrep.aer_02;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
-import com.teragrep.aer_02.config.SyslogConfig;
-import com.teragrep.aer_02.config.source.Sourceable;
 import com.teragrep.rlo_14.SDElement;
 import com.teragrep.rlo_14.SyslogMessage;
 import com.teragrep.rlo_14.*;
@@ -64,20 +62,11 @@ final class EventDataConsumer {
 
     // Note: Checkpointing is handled automatically.
     private final Output output;
-    private final String realHostName;
-    private final SyslogConfig syslogConfig;
     private final MetricRegistry metricRegistry;
 
-    EventDataConsumer(
-            final Sourceable configSource,
-            final Output output,
-            final String hostname,
-            final MetricRegistry metricRegistry
-    ) {
+    EventDataConsumer(final Output output, final MetricRegistry metricRegistry) {
         this.metricRegistry = metricRegistry;
         this.output = output;
-        this.realHostName = hostname;
-        this.syslogConfig = new SyslogConfig(configSource);
     }
 
     public void accept(final SyslogMessage syslogMessage) {

--- a/src/main/java/com/teragrep/aer_02/SyslogBridge.java
+++ b/src/main/java/com/teragrep/aer_02/SyslogBridge.java
@@ -61,6 +61,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Level;
 
 public class SyslogBridge {
 
@@ -114,9 +115,10 @@ public class SyslogBridge {
             ExecutionContext context
     ) {
         try {
-            context.getLogger().fine("eventHubTriggerToSyslog triggered");
-            context.getLogger().fine("Got events: " + events.length);
-            context.getLogger().info("initializing at " + this);
+            if (context.getLogger().isLoggable(Level.FINE)) {
+                context.getLogger().fine("eventHubTriggerToSyslog triggered");
+                context.getLogger().fine("Got events: " + events.length);
+            }
 
             final LazyInstance lazyInstance = LazyInstance.lazySingletonInstance();
             final DefaultOutput defaultOutput = lazyInstance.defaultOutput();
@@ -126,15 +128,15 @@ public class SyslogBridge {
             final Map<String, Plugin> mappedPlugins = lazyPluginMapInstance.mappedPlugins();
             final Plugin defaultPlugin = lazyPluginMapInstance.defaultPlugin();
 
-            context.getLogger().info("initialized at " + this);
-
             final EventDataConsumer consumer = new EventDataConsumer(defaultOutput, lazyInstance.metricRegistry());
 
             for (int index = 0; index < events.length; index++) {
                 final String event = events[index];
                 if (event != null) {
                     final ZonedDateTime et = ZonedDateTime.parse(enqueuedTimeUtcArray.get(index) + "Z"); // needed as the UTC time presented does not have a TZ
-                    context.getLogger().fine("Accepting event: " + event);
+                    if (context.getLogger().isLoggable(Level.FINE)) {
+                        context.getLogger().fine("Accepting event: " + event);
+                    }
 
                     Plugin plugin;
                     try {
@@ -164,7 +166,9 @@ public class SyslogBridge {
             }
         }
         catch (Throwable t) {
-            context.getLogger().severe("exiting because caught Throwable: " + t);
+            if (context.getLogger().isLoggable(Level.SEVERE)) {
+                context.getLogger().severe("exiting because caught Throwable: " + t);
+            }
             System.exit(1);
         }
     }

--- a/src/main/java/com/teragrep/aer_02/json/JsonResourceId.java
+++ b/src/main/java/com/teragrep/aer_02/json/JsonResourceId.java
@@ -1,0 +1,106 @@
+/*
+ * Teragrep Eventhub Reader as an Azure Function
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.aer_02.json;
+
+import jakarta.json.*;
+import jakarta.json.stream.JsonParsingException;
+
+import java.io.StringReader;
+import java.util.Objects;
+
+public final class JsonResourceId {
+
+    private final String message;
+
+    public JsonResourceId(final String message) {
+        this.message = message;
+    }
+
+    public String resourceId() {
+        final String resourceIdKey = "resourceId";
+        final JsonStructure mainStructure;
+        try (final JsonReader reader = Json.createReader(new StringReader(message))) {
+            mainStructure = reader.read();
+        }
+        catch (JsonParsingException e) {
+            // Could not parse JSON, return empty id
+            return "";
+        }
+
+        if (mainStructure == null || !mainStructure.getValueType().equals(JsonValue.ValueType.OBJECT)) {
+            // No main structure or it wasn't a JSONObject, return empty id
+            return "";
+        }
+
+        final JsonObject mainObject = mainStructure.asJsonObject();
+
+        if (!mainObject.containsKey(resourceIdKey)) {
+            // No "resourceId" key present in JSONObject, return empty id
+            return "";
+        }
+
+        if (!mainObject.get(resourceIdKey).getValueType().equals(JsonValue.ValueType.STRING)) {
+            // resourceId was not a string, return empty id
+            return "";
+        }
+
+        return mainObject.getJsonString(resourceIdKey).getString();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final JsonResourceId that = (JsonResourceId) o;
+        return Objects.equals(message, that.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(message);
+    }
+}

--- a/src/main/java/com/teragrep/aer_02/json/JsonResourceId.java
+++ b/src/main/java/com/teragrep/aer_02/json/JsonResourceId.java
@@ -59,7 +59,7 @@ public final class JsonResourceId {
         this.message = message;
     }
 
-    public String resourceId() {
+    public String resourceId() throws JsonException {
         final String resourceIdKey = "resourceId";
         final JsonStructure mainStructure;
         try (final JsonReader reader = Json.createReader(new StringReader(message))) {
@@ -67,24 +67,24 @@ public final class JsonResourceId {
         }
         catch (JsonParsingException e) {
             // Could not parse JSON, return empty id
-            return "";
+            throw new JsonException("Could not parse message into JSON", e);
         }
 
         if (mainStructure == null || !mainStructure.getValueType().equals(JsonValue.ValueType.OBJECT)) {
             // No main structure or it wasn't a JSONObject, return empty id
-            return "";
+            throw new JsonException("Missing main structure, expected JSON object");
         }
 
         final JsonObject mainObject = mainStructure.asJsonObject();
 
         if (!mainObject.containsKey(resourceIdKey)) {
             // No "resourceId" key present in JSONObject, return empty id
-            return "";
+            throw new JsonException("Missing key <" + resourceIdKey + "> in main structure");
         }
 
         if (!mainObject.get(resourceIdKey).getValueType().equals(JsonValue.ValueType.STRING)) {
             // resourceId was not a string, return empty id
-            return "";
+            throw new JsonException("Key <" + resourceIdKey + "> was not of the expected type String");
         }
 
         return mainObject.getJsonString(resourceIdKey).getString();

--- a/src/main/java/com/teragrep/aer_02/plugin/DefaultPlugin.java
+++ b/src/main/java/com/teragrep/aer_02/plugin/DefaultPlugin.java
@@ -1,0 +1,137 @@
+/*
+ * Teragrep Eventhub Reader as an Azure Function
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.aer_02.plugin;
+
+import com.teragrep.akv_01.plugin.Plugin;
+import com.teragrep.rlo_14.Facility;
+import com.teragrep.rlo_14.SDElement;
+import com.teragrep.rlo_14.Severity;
+import com.teragrep.rlo_14.SyslogMessage;
+
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class DefaultPlugin implements Plugin {
+
+    private final String realHostname;
+    private final String syslogHostname;
+    private final String syslogAppname;
+
+    public DefaultPlugin(final String realHostname, final String syslogHostname, final String syslogAppname) {
+        this.realHostname = realHostname;
+        this.syslogHostname = syslogHostname;
+        this.syslogAppname = syslogAppname;
+    }
+
+    @Override
+    public SyslogMessage syslogMessage(
+            final String eventData,
+            final Map<String, Object> partitionContext,
+            final ZonedDateTime enqueuedTime,
+            final String offset,
+            final Map<String, Object> props,
+            final Map<String, Object> systemProps
+    ) {
+        final SDElement sdId = new SDElement("event_id@48577")
+                .addSDParam("uuid", UUID.randomUUID().toString())
+                .addSDParam("hostname", realHostname)
+                .addSDParam("unixtime", Instant.now().toString())
+                .addSDParam("id_source", "aer_02");
+
+        final SDElement sdPartition = new SDElement("aer_02_partition@48577")
+                .addSDParam(
+                        "fully_qualified_namespace",
+                        String.valueOf(partitionContext.getOrDefault("FullyQualifiedNamespace", ""))
+                )
+                .addSDParam("eventhub_name", String.valueOf(partitionContext.getOrDefault("EventHubName", "")))
+                .addSDParam("partition_id", String.valueOf(partitionContext.getOrDefault("PartitionId", "")))
+                .addSDParam("consumer_group", String.valueOf(partitionContext.getOrDefault("ConsumerGroup", "")));
+
+        final String partitionKey = String.valueOf(systemProps.getOrDefault("PartitionKey", ""));
+
+        final SDElement sdEvent = new SDElement("aer_02_event@48577")
+                .addSDParam("offset", offset == null ? "" : offset)
+                .addSDParam("enqueued_time", enqueuedTime == null ? "" : enqueuedTime.toString())
+                .addSDParam("partition_key", partitionKey == null ? "" : partitionKey);
+        props.forEach((key, value) -> sdEvent.addSDParam("property_" + key, value.toString()));
+
+        final SDElement sdComponentInfo = new SDElement("aer_02@48577")
+                .addSDParam("timestamp_source", enqueuedTime == null ? "generated" : "timeEnqueued");
+
+        return new SyslogMessage()
+                .withSeverity(Severity.INFORMATIONAL)
+                .withFacility(Facility.LOCAL0)
+                .withTimestamp(
+                        enqueuedTime == null ? Instant.now().toEpochMilli() : enqueuedTime.toInstant().toEpochMilli()
+                )
+                .withHostname(syslogHostname)
+                .withAppName(syslogAppname)
+                .withSDElement(sdId)
+                .withSDElement(sdPartition)
+                .withSDElement(sdEvent)
+                .withSDElement(sdComponentInfo)
+                .withMsgId(String.valueOf(systemProps.getOrDefault("SequenceNumber", "0")))
+                .withMsg(eventData);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DefaultPlugin that = (DefaultPlugin) o;
+        return Objects.equals(realHostname, that.realHostname) && Objects.equals(syslogHostname, that.syslogHostname)
+                && Objects.equals(syslogAppname, that.syslogAppname);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(realHostname, syslogHostname, syslogAppname);
+    }
+}

--- a/src/main/java/com/teragrep/aer_02/plugin/DefaultPluginFactory.java
+++ b/src/main/java/com/teragrep/aer_02/plugin/DefaultPluginFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Teragrep Eventhub Reader as an Azure Function
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.aer_02.plugin;
+
+import com.teragrep.akv_01.plugin.Plugin;
+import com.teragrep.akv_01.plugin.PluginFactory;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+
+import java.io.StringReader;
+
+public final class DefaultPluginFactory implements PluginFactory {
+
+    @Override
+    public Plugin plugin(final String json) {
+        final JsonObject jsonObject;
+        try (JsonReader reader = Json.createReader(new StringReader(json))) {
+            jsonObject = reader.readObject();
+        }
+        return new DefaultPlugin(
+                jsonObject.getString("realHostname"),
+                jsonObject.getString("syslogHostname"),
+                jsonObject.getString("syslogAppname")
+        );
+    }
+}

--- a/src/main/java/com/teragrep/aer_02/plugin/LazyPluginMapInstance.java
+++ b/src/main/java/com/teragrep/aer_02/plugin/LazyPluginMapInstance.java
@@ -64,7 +64,8 @@ import java.util.logging.Logger;
  */
 public final class LazyPluginMapInstance {
 
-    private final Map<String, Plugin> resourceIdToPluginMap;
+    private final Map<String, Plugin> mappedPlugins;
+    private final Plugin defaultPlugin;
 
     private LazyPluginMapInstance() {
         final Logger logger = Logger.getAnonymousLogger();
@@ -81,13 +82,16 @@ public final class LazyPluginMapInstance {
         final Map<String, PluginFactoryConfig> pluginFactoryConfigs = pluginMap.asUnmodifiableMap();
         final String defaultPluginFactoryClassName = pluginMap.defaultPluginFactoryClassName();
 
-        this.resourceIdToPluginMap = new ResourceIdToPluginMap(
+        final ResourceIdToPluginMap resourceIdToPluginMap = new ResourceIdToPluginMap(
                 pluginFactoryConfigs,
                 defaultPluginFactoryClassName,
                 hostname,
                 new SyslogConfig(configSource),
                 logger
-        ).asUnmodifiableMap();
+        );
+
+        this.mappedPlugins = resourceIdToPluginMap.asUnmodifiableMap();
+        this.defaultPlugin = resourceIdToPluginMap.defaultPlugin();
     }
 
     public static LazyPluginMapInstance lazySingletonInstance() {
@@ -101,7 +105,11 @@ public final class LazyPluginMapInstance {
         static final LazyPluginMapInstance INSTANCE = new LazyPluginMapInstance();
     }
 
-    public Map<String, Plugin> resourceIdToPluginMap() {
-        return resourceIdToPluginMap;
+    public Map<String, Plugin> mappedPlugins() {
+        return mappedPlugins;
+    }
+
+    public Plugin defaultPlugin() {
+        return defaultPlugin;
     }
 }

--- a/src/main/java/com/teragrep/aer_02/plugin/PluginConfiguration.java
+++ b/src/main/java/com/teragrep/aer_02/plugin/PluginConfiguration.java
@@ -1,0 +1,92 @@
+/*
+ * Teragrep Eventhub Reader as an Azure Function
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.aer_02.plugin;
+
+import com.teragrep.aer_02.config.source.Sourceable;
+import com.teragrep.akv_01.json.JsonFile;
+import jakarta.json.Json;
+import jakarta.json.JsonStructure;
+import jakarta.json.JsonValue;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public final class PluginConfiguration {
+
+    private final Sourceable configSource;
+
+    public PluginConfiguration(final Sourceable configSource) {
+        this.configSource = configSource;
+    }
+
+    public JsonStructure asJson() throws IOException {
+        final String configPath = configSource.source("plugins.config.path", "");
+
+        if (configPath == null || configPath.isEmpty()) {
+            return Json
+                    .createObjectBuilder()
+                    .add("defaultPluginFactoryClass", "com.teragrep.aer_02.plugin.DefaultPluginFactory")
+                    .add("resourceIds", JsonValue.EMPTY_JSON_ARRAY)
+                    .build();
+        }
+
+        return new JsonFile(configPath).asJsonStructure();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PluginConfiguration that = (PluginConfiguration) o;
+        return Objects.equals(configSource, that.configSource);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(configSource);
+    }
+}

--- a/src/main/java/com/teragrep/aer_02/plugin/ResourceIdToPluginMap.java
+++ b/src/main/java/com/teragrep/aer_02/plugin/ResourceIdToPluginMap.java
@@ -45,7 +45,6 @@
  */
 package com.teragrep.aer_02.plugin;
 
-import com.microsoft.azure.functions.ExecutionContext;
 import com.teragrep.aer_02.config.SyslogConfig;
 import com.teragrep.akv_01.plugin.*;
 import jakarta.json.Json;
@@ -55,6 +54,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.logging.Logger;
 
 public final class ResourceIdToPluginMap {
 
@@ -62,20 +62,20 @@ public final class ResourceIdToPluginMap {
     private final String defaultPluginFactoryClassName;
     private final String realHostname;
     private final SyslogConfig syslogConfig;
-    private final ExecutionContext context;
+    private final Logger logger;
 
     public ResourceIdToPluginMap(
             final Map<String, PluginFactoryConfig> pluginFactoryConfigs,
             final String defaultPluginFactoryClassName,
             final String realHostname,
             final SyslogConfig syslogConfig,
-            final ExecutionContext context
+            final Logger logger
     ) {
         this.pluginFactoryConfigs = pluginFactoryConfigs;
         this.defaultPluginFactoryClassName = defaultPluginFactoryClassName;
         this.realHostname = realHostname;
         this.syslogConfig = syslogConfig;
-        this.context = context;
+        this.logger = logger;
     }
 
     public Map<String, Plugin> asUnmodifiableMap() {
@@ -106,7 +106,7 @@ public final class ResourceIdToPluginMap {
                 ClassNotFoundException | InvocationTargetException | NoSuchMethodException | InstantiationException
                 | IllegalAccessException e
         ) {
-            context.getLogger().throwing(ResourceIdToPluginMap.class.getName(), "asUnmodifiableMap", e);
+            logger.throwing(ResourceIdToPluginMap.class.getName(), "asUnmodifiableMap", e);
             throw new IllegalStateException(e);
         }
     }
@@ -119,11 +119,11 @@ public final class ResourceIdToPluginMap {
         ResourceIdToPluginMap that = (ResourceIdToPluginMap) o;
         return Objects.equals(pluginFactoryConfigs, that.pluginFactoryConfigs) && Objects
                 .equals(defaultPluginFactoryClassName, that.defaultPluginFactoryClassName)
-                && Objects.equals(realHostname, that.realHostname) && Objects.equals(syslogConfig, that.syslogConfig) && Objects.equals(context, that.context);
+                && Objects.equals(realHostname, that.realHostname) && Objects.equals(syslogConfig, that.syslogConfig);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(pluginFactoryConfigs, defaultPluginFactoryClassName, realHostname, syslogConfig, context);
+        return Objects.hash(pluginFactoryConfigs, defaultPluginFactoryClassName, realHostname, syslogConfig);
     }
 }

--- a/src/main/java/com/teragrep/aer_02/plugin/ResourceIdToPluginMap.java
+++ b/src/main/java/com/teragrep/aer_02/plugin/ResourceIdToPluginMap.java
@@ -81,19 +81,16 @@ public final class ResourceIdToPluginMap {
     public Map<String, Plugin> asUnmodifiableMap() {
         final Map<String, Plugin> rv = new HashMap<>();
         pluginFactoryConfigs.forEach((id, cfg) -> rv.put(id, newPlugin(cfg)));
-
-        // default plugin
-        rv
-                .put(
-                        "",
-                        newPlugin(
-                                new PluginFactoryConfigImpl(
-                                        defaultPluginFactoryClassName,
-                                        Json.createObjectBuilder().add("realHostname", realHostname).add("syslogHostname", syslogConfig.hostName()).add("syslogAppname", syslogConfig.appName()).build().toString()
-                                )
-                        )
-                );
         return Collections.unmodifiableMap(rv);
+    }
+
+    public Plugin defaultPlugin() {
+        return newPlugin(
+                new PluginFactoryConfigImpl(
+                        defaultPluginFactoryClassName,
+                        Json.createObjectBuilder().add("realHostname", realHostname).add("syslogHostname", syslogConfig.hostName()).add("syslogAppname", syslogConfig.appName()).build().toString()
+                )
+        );
     }
 
     private Plugin newPlugin(final PluginFactoryConfig cfg) {

--- a/src/main/java/com/teragrep/aer_02/plugin/ResourceIdToPluginMap.java
+++ b/src/main/java/com/teragrep/aer_02/plugin/ResourceIdToPluginMap.java
@@ -1,0 +1,129 @@
+/*
+ * Teragrep Eventhub Reader as an Azure Function
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.aer_02.plugin;
+
+import com.microsoft.azure.functions.ExecutionContext;
+import com.teragrep.aer_02.config.SyslogConfig;
+import com.teragrep.akv_01.plugin.*;
+import jakarta.json.Json;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public final class ResourceIdToPluginMap {
+
+    private final Map<String, PluginFactoryConfig> pluginFactoryConfigs;
+    private final String defaultPluginFactoryClassName;
+    private final String realHostname;
+    private final SyslogConfig syslogConfig;
+    private final ExecutionContext context;
+
+    public ResourceIdToPluginMap(
+            final Map<String, PluginFactoryConfig> pluginFactoryConfigs,
+            final String defaultPluginFactoryClassName,
+            final String realHostname,
+            final SyslogConfig syslogConfig,
+            final ExecutionContext context
+    ) {
+        this.pluginFactoryConfigs = pluginFactoryConfigs;
+        this.defaultPluginFactoryClassName = defaultPluginFactoryClassName;
+        this.realHostname = realHostname;
+        this.syslogConfig = syslogConfig;
+        this.context = context;
+    }
+
+    public Map<String, Plugin> asUnmodifiableMap() {
+        final Map<String, Plugin> rv = new HashMap<>();
+        pluginFactoryConfigs.forEach((id, cfg) -> rv.put(id, newPlugin(cfg)));
+
+        // default plugin
+        rv
+                .put(
+                        "",
+                        newPlugin(
+                                new PluginFactoryConfigImpl(
+                                        defaultPluginFactoryClassName,
+                                        Json.createObjectBuilder().add("realHostname", realHostname).add("syslogHostname", syslogConfig.hostName()).add("syslogAppname", syslogConfig.appName()).build().toString()
+                                )
+                        )
+                );
+        return Collections.unmodifiableMap(rv);
+    }
+
+    private Plugin newPlugin(final PluginFactoryConfig cfg) {
+        try {
+            return new PluginFactoryInitialization(cfg.pluginFactoryClassName())
+                    .pluginFactory()
+                    .plugin(cfg.configPath());
+        }
+        catch (
+                ClassNotFoundException | InvocationTargetException | NoSuchMethodException | InstantiationException
+                | IllegalAccessException e
+        ) {
+            context.getLogger().throwing(ResourceIdToPluginMap.class.getName(), "asUnmodifiableMap", e);
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ResourceIdToPluginMap that = (ResourceIdToPluginMap) o;
+        return Objects.equals(pluginFactoryConfigs, that.pluginFactoryConfigs) && Objects
+                .equals(defaultPluginFactoryClassName, that.defaultPluginFactoryClassName)
+                && Objects.equals(realHostname, that.realHostname) && Objects.equals(syslogConfig, that.syslogConfig) && Objects.equals(context, that.context);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pluginFactoryConfigs, defaultPluginFactoryClassName, realHostname, syslogConfig, context);
+    }
+}

--- a/src/test/java/com/teragrep/aer_02/EventDataConsumerTest.java
+++ b/src/test/java/com/teragrep/aer_02/EventDataConsumerTest.java
@@ -77,12 +77,7 @@ public class EventDataConsumerTest {
         Map<String, Object> systemProps = new HashMap<>();
         systemProps.put("SequenceNumber", "1");
         MetricRegistry metricRegistry = new MetricRegistry();
-        EventDataConsumer eventDataConsumer = new EventDataConsumer(
-                configSource,
-                new OutputFake(),
-                new Hostname("localhost").hostname(),
-                metricRegistry
-        );
+        EventDataConsumer eventDataConsumer = new EventDataConsumer(new OutputFake(), metricRegistry);
 
         final double records = 10;
         for (int i = 0; i < records; i++) {

--- a/src/test/java/com/teragrep/aer_02/EventDataConsumerTlsTest.java
+++ b/src/test/java/com/teragrep/aer_02/EventDataConsumerTlsTest.java
@@ -51,6 +51,7 @@ import com.teragrep.aer_02.config.source.EnvironmentSource;
 import com.teragrep.aer_02.config.source.Sourceable;
 import com.teragrep.aer_02.fakes.PartitionContextFake;
 import com.teragrep.aer_02.fakes.SystemPropsFake;
+import com.teragrep.aer_02.plugin.DefaultPlugin;
 import com.teragrep.net_01.channel.socket.TLSFactory;
 import com.teragrep.net_01.eventloop.EventLoop;
 import com.teragrep.net_01.eventloop.EventLoopFactory;
@@ -199,7 +200,7 @@ public class EventDataConsumerTlsTest {
 
         for (int i = 0; i < eventDatas.size(); i++) {
             edc
-                    .accept(eventDatas.get(i), pcf.asMap(), ZonedDateTime.parse(enqueuedArray.get(i) + "Z"), offsets.get(i), propsArray[i], sysPropsArray[i]);
+                    .accept((new DefaultPlugin("localhost.localdomain", "localhost.localdomain", "aer-02").syslogMessage(eventDatas.get(i), pcf.asMap(), ZonedDateTime.parse(enqueuedArray.get(i) + "Z"), offsets.get(i), propsArray[i], sysPropsArray[i])));
         }
 
         Assertions.assertEquals(3, messages.size());

--- a/src/test/java/com/teragrep/aer_02/EventDataConsumerTlsTest.java
+++ b/src/test/java/com/teragrep/aer_02/EventDataConsumerTlsTest.java
@@ -183,7 +183,7 @@ public class EventDataConsumerTlsTest {
                 sslContextSupplier
         );
 
-        final EventDataConsumer edc = new EventDataConsumer(configSource, output, "localhost", metricRegistry);
+        final EventDataConsumer edc = new EventDataConsumer(output, metricRegistry);
 
         // Fake data
         PartitionContextFake pcf = new PartitionContextFake("eventhub.123", "test1", "$Default", "0");

--- a/src/test/java/com/teragrep/aer_02/fakes/SourceableFake.java
+++ b/src/test/java/com/teragrep/aer_02/fakes/SourceableFake.java
@@ -1,0 +1,85 @@
+/*
+ * Teragrep Eventhub Reader as an Azure Function
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.aer_02.fakes;
+
+import com.teragrep.aer_02.config.source.Sourceable;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class SourceableFake implements Sourceable {
+
+    private final Map<String, String> map;
+
+    public SourceableFake() {
+        this(new HashMap<>());
+    }
+
+    public SourceableFake(final Map<String, String> map) {
+        this.map = map;
+    }
+
+    @Override
+    public String source(final String name, final String defaultValue) {
+        map.putIfAbsent("relp.tls.mode", "none");
+        map.putIfAbsent("plugins.config.path", "");
+        map.putIfAbsent("relp.connection.timeout", "2500");
+        map.putIfAbsent("relp.transaction.read.timeout", "1500");
+        map.putIfAbsent("relp.transaction.write.timeout", "1500");
+        map.putIfAbsent("relp.connection.retry.interval", "500");
+        map.putIfAbsent("relp.connection.port", "601");
+        map.putIfAbsent("relp.connection.address", "localhost");
+        map.putIfAbsent("relp.rebind.request.amount", "100000");
+        map.putIfAbsent("relp.rebind.enabled", "true");
+        map.putIfAbsent("relp.max.idle.duration", Duration.ofMillis(150000L).toString());
+        map.putIfAbsent("relp.max.idle.enabled", "false");
+        map.putIfAbsent("relp.connection.keepalive", "true");
+        map.putIfAbsent("syslog.appname", "aer-02");
+        map.putIfAbsent("syslog.hostname", "localhost.localdomain");
+        return map.getOrDefault(name, defaultValue);
+    }
+}

--- a/src/test/java/com/teragrep/aer_02/fakes/ThrowingPlugin.java
+++ b/src/test/java/com/teragrep/aer_02/fakes/ThrowingPlugin.java
@@ -1,0 +1,67 @@
+/*
+ * Teragrep Eventhub Reader as an Azure Function
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.aer_02.fakes;
+
+import com.teragrep.akv_01.plugin.Plugin;
+import com.teragrep.rlo_14.SyslogMessage;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+public final class ThrowingPlugin implements Plugin {
+
+    @Override
+    public SyslogMessage syslogMessage(
+            String s,
+            Map<String, Object> map,
+            ZonedDateTime zonedDateTime,
+            String s1,
+            Map<String, Object> map1,
+            Map<String, Object> map2
+    ) {
+        throw new RuntimeException("test");
+    }
+}

--- a/src/test/java/com/teragrep/aer_02/fakes/ThrowingPluginFactory.java
+++ b/src/test/java/com/teragrep/aer_02/fakes/ThrowingPluginFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Teragrep Eventhub Reader as an Azure Function
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.aer_02.fakes;
+
+import com.teragrep.akv_01.plugin.Plugin;
+import com.teragrep.akv_01.plugin.PluginFactory;
+
+public final class ThrowingPluginFactory implements PluginFactory {
+
+    @Override
+    public Plugin plugin(String s) {
+        return new ThrowingPlugin();
+    }
+}

--- a/src/test/java/com/teragrep/aer_02/json/JsonResourceIdTest.java
+++ b/src/test/java/com/teragrep/aer_02/json/JsonResourceIdTest.java
@@ -1,0 +1,88 @@
+/*
+ * Teragrep Eventhub Reader as an Azure Function
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.aer_02.json;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public final class JsonResourceIdTest {
+
+    @Test
+    void testWithCorrectJson() {
+        JsonObject json = Json.createObjectBuilder().add("resourceId", "dummyId").build();
+        JsonResourceId jsonResourceId = new JsonResourceId(json.toString());
+        Assertions.assertEquals("dummyId", jsonResourceId.resourceId());
+    }
+
+    @Test
+    void testWithEmptyJsonObject() {
+        JsonObject json = Json.createObjectBuilder().build();
+        JsonResourceId jsonResourceId = new JsonResourceId(json.toString());
+        Assertions.assertEquals("", jsonResourceId.resourceId());
+    }
+
+    @Test
+    void testWithEmptyJsonArray() {
+        JsonArray json = Json.createArrayBuilder().build();
+        JsonResourceId jsonResourceId = new JsonResourceId(json.toString());
+        Assertions.assertEquals("", jsonResourceId.resourceId());
+    }
+
+    @Test
+    void testWithInvalidJson() {
+        JsonResourceId jsonResourceId = new JsonResourceId("some text that is not in json format");
+        Assertions.assertEquals("", jsonResourceId.resourceId());
+    }
+
+    @Test
+    void testEqualsContract() {
+        EqualsVerifier.forClass(JsonResourceId.class).verify();
+    }
+}

--- a/src/test/java/com/teragrep/aer_02/json/JsonResourceIdTest.java
+++ b/src/test/java/com/teragrep/aer_02/json/JsonResourceIdTest.java
@@ -47,6 +47,7 @@ package com.teragrep.aer_02.json;
 
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
+import jakarta.json.JsonException;
 import jakarta.json.JsonObject;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Assertions;
@@ -65,20 +66,23 @@ public final class JsonResourceIdTest {
     void testWithEmptyJsonObject() {
         JsonObject json = Json.createObjectBuilder().build();
         JsonResourceId jsonResourceId = new JsonResourceId(json.toString());
-        Assertions.assertEquals("", jsonResourceId.resourceId());
+        JsonException e = Assertions.assertThrows(JsonException.class, jsonResourceId::resourceId);
+        Assertions.assertEquals("Missing key <resourceId> in main structure", e.getMessage());
     }
 
     @Test
     void testWithEmptyJsonArray() {
         JsonArray json = Json.createArrayBuilder().build();
         JsonResourceId jsonResourceId = new JsonResourceId(json.toString());
-        Assertions.assertEquals("", jsonResourceId.resourceId());
+        JsonException e = Assertions.assertThrows(JsonException.class, jsonResourceId::resourceId);
+        Assertions.assertEquals("Missing main structure, expected JSON object", e.getMessage());
     }
 
     @Test
     void testWithInvalidJson() {
         JsonResourceId jsonResourceId = new JsonResourceId("some text that is not in json format");
-        Assertions.assertEquals("", jsonResourceId.resourceId());
+        JsonException e = Assertions.assertThrows(JsonException.class, jsonResourceId::resourceId);
+        Assertions.assertEquals("Could not parse message into JSON", e.getMessage());
     }
 
     @Test

--- a/src/test/java/com/teragrep/aer_02/plugin/DefaultPluginTest.java
+++ b/src/test/java/com/teragrep/aer_02/plugin/DefaultPluginTest.java
@@ -43,61 +43,46 @@
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
  */
-package com.teragrep.aer_02;
+package com.teragrep.aer_02.plugin;
 
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.MetricRegistry;
-import com.teragrep.aer_02.config.source.PropertySource;
-import com.teragrep.aer_02.config.source.Sourceable;
-import com.teragrep.aer_02.fakes.OutputFake;
-import com.teragrep.aer_02.plugin.DefaultPlugin;
+import com.teragrep.rlo_14.SyslogMessage;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.codahale.metrics.MetricRegistry.name;
-
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class EventDataConsumerTest {
-
-    private final Sourceable configSource = new PropertySource();
+public final class DefaultPluginTest {
 
     @Test
-    public void testLatencyMetric() {
-        Map<String, Object> partitionContext = new HashMap<>();
+    void testDefaultPluginCreateSyslogMessage() {
+        final Map<String, Object> partitionContext = new HashMap<>();
         partitionContext.put("FullyQualifiedNamespace", "eventhub.123");
         partitionContext.put("EventHubName", "test1");
         partitionContext.put("ConsumerGroup", "$Default");
         partitionContext.put("PartitionId", "0");
-        Map<String, Object> props = new HashMap<>();
-        Map<String, Object> systemProps = new HashMap<>();
+        final Map<String, Object> props = new HashMap<>();
+        final Map<String, Object> systemProps = new HashMap<>();
         systemProps.put("SequenceNumber", "1");
-        MetricRegistry metricRegistry = new MetricRegistry();
-        EventDataConsumer eventDataConsumer = new EventDataConsumer(
-                configSource,
-                new OutputFake(),
-                new Hostname("localhost").hostname(),
-                metricRegistry
-        );
+        final ZonedDateTime enqueuedTime = ZonedDateTime.of(2025, 1, 1, 1, 1, 1, 0, ZoneId.of("UTC"));
 
-        final double records = 10;
-        for (int i = 0; i < records; i++) {
-            if (i >= 5) {
-                partitionContext.put("PartitionId", "1");
-            }
-            eventDataConsumer
-                    .accept(new DefaultPlugin("real", "host", "app").syslogMessage("event", partitionContext, ZonedDateTime.now().minusSeconds(10), String.valueOf(i), props, systemProps));
-        }
+        final DefaultPlugin defaultPlugin = new DefaultPlugin("realHostname", "syslogHostname", "syslogAppname");
+        final SyslogMessage msg = defaultPlugin
+                .syslogMessage("event", partitionContext, enqueuedTime, "0", props, systemProps);
 
-        // 5 records for each partition
-        Gauge<Long> gauge1 = metricRegistry.gauge(name(EventDataConsumer.class, "latency-seconds", "0"));
-        Gauge<Long> gauge2 = metricRegistry.gauge(name(EventDataConsumer.class, "latency-seconds", "1"));
+        Assertions.assertEquals("event", msg.getMsg());
+        // aer_02@48577; aer_02_event@48577; aer_02_partition@48577; event_id@48577
+        Assertions.assertEquals(4, msg.getSDElements().size());
+        Assertions.assertEquals("syslogHostname", msg.getHostname());
+        Assertions.assertEquals("syslogAppname", msg.getAppName());
+        Assertions.assertEquals(enqueuedTime.toInstant().toString(), msg.getTimestamp());
+    }
 
-        Assertions.assertEquals(gauge1.getValue(), 10);
-        Assertions.assertEquals(gauge2.getValue(), 10);
+    @Test
+    void testEqualsContract() {
+        EqualsVerifier.forClass(DefaultPlugin.class).verify();
     }
 }

--- a/src/test/java/com/teragrep/aer_02/plugin/PluginConfigurationTest.java
+++ b/src/test/java/com/teragrep/aer_02/plugin/PluginConfigurationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Teragrep Eventhub Reader as an Azure Function
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.aer_02.plugin;
+
+import com.teragrep.aer_02.fakes.SourceableFake;
+import jakarta.json.JsonStructure;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class PluginConfigurationTest {
+
+    @Test
+    void testPluginConfigurationDefault() {
+        PluginConfiguration pluginCfg = new PluginConfiguration(new SourceableFake());
+        JsonStructure js = Assertions.assertDoesNotThrow(pluginCfg::asJson);
+
+        // Should default to com.teragrep.aer_02.plugin.DefaultPluginFactory
+        Assertions
+                .assertEquals(
+                        "com.teragrep.aer_02.plugin.DefaultPluginFactory",
+                        js.asJsonObject().getString("defaultPluginFactoryClass")
+                );
+    }
+
+    @Test
+    void testPluginConfigurationFromFile() {
+        Map<String, String> config = new HashMap<>();
+        config.put("plugins.config.path", "src/test/resources/plugincfg.json");
+        PluginConfiguration pluginCfg = new PluginConfiguration(new SourceableFake(config));
+        JsonStructure js = Assertions.assertDoesNotThrow(pluginCfg::asJson);
+
+        // Should default to com.teragrep.aer_02.fakes.ThrowingPluginFactory
+        Assertions
+                .assertEquals(
+                        "com.teragrep.aer_02.fakes.ThrowingPluginFactory",
+                        js.asJsonObject().getString("defaultPluginFactoryClass")
+                );
+        // Should also have com.teragrep.aer_02.plugin.DefaultPluginFactory for resourceId="123"
+        Assertions
+                .assertEquals("123", js.asJsonObject().getJsonArray("resourceIds").getJsonObject(0).getString("resourceId"));
+        Assertions
+                .assertEquals(
+                        "com.teragrep.aer_02.plugin.DefaultPluginFactory", js.asJsonObject().getJsonArray("resourceIds").getJsonObject(0).getString("pluginFactoryClass")
+                );
+    }
+
+    @Test
+    void testEqualsContract() {
+        EqualsVerifier.forClass(PluginConfiguration.class).verify();
+    }
+}

--- a/src/test/java/com/teragrep/aer_02/plugin/ResourceIdToPluginMapTest.java
+++ b/src/test/java/com/teragrep/aer_02/plugin/ResourceIdToPluginMapTest.java
@@ -1,0 +1,106 @@
+/*
+ * Teragrep Eventhub Reader as an Azure Function
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.aer_02.plugin;
+
+import com.microsoft.azure.functions.ExecutionContext;
+import com.teragrep.aer_02.config.SyslogConfig;
+import com.teragrep.aer_02.fakes.ExecutionContextFake;
+import com.teragrep.aer_02.fakes.ThrowingPlugin;
+import com.teragrep.akv_01.plugin.Plugin;
+import com.teragrep.akv_01.plugin.PluginFactoryConfig;
+import com.teragrep.akv_01.plugin.PluginFactoryConfigImpl;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class ResourceIdToPluginMapTest {
+
+    @Test
+    void testWithOnePluginFactory() {
+        final Map<String, PluginFactoryConfig> configs = new HashMap<>();
+        configs.put("123", new PluginFactoryConfigImpl("com.teragrep.aer_02.fakes.ThrowingPluginFactory", "path"));
+        final ExecutionContext context = new ExecutionContextFake();
+
+        final ResourceIdToPluginMap resourceIdToPluginMap = new ResourceIdToPluginMap(
+                configs,
+                "com.teragrep.aer_02.plugin.DefaultPluginFactory",
+                "host",
+                new SyslogConfig("app", "host"),
+                context
+        );
+
+        Map<String, Plugin> plugins = resourceIdToPluginMap.asUnmodifiableMap();
+        Assertions.assertEquals(2, plugins.size());
+        Assertions.assertTrue(plugins.containsKey("123"));
+        Assertions.assertEquals(ThrowingPlugin.class.getName(), plugins.get("123").getClass().getName());
+        Assertions.assertEquals(DefaultPlugin.class.getName(), plugins.get("").getClass().getName());
+    }
+
+    @Test
+    void testWithNoPluginFactories() {
+        final Map<String, PluginFactoryConfig> configs = new HashMap<>();
+        final ExecutionContext context = new ExecutionContextFake();
+        final ResourceIdToPluginMap resourceIdToPluginMap = new ResourceIdToPluginMap(
+                configs,
+                "com.teragrep.aer_02.plugin.DefaultPluginFactory",
+                "host",
+                new SyslogConfig("app", "host"),
+                context
+        );
+
+        Map<String, Plugin> plugins = resourceIdToPluginMap.asUnmodifiableMap();
+        Assertions.assertEquals(1, plugins.size());
+        Assertions.assertEquals(DefaultPlugin.class.getName(), plugins.get("").getClass().getName());
+    }
+
+    @Test
+    void testEqualsContract() {
+        EqualsVerifier.forClass(ResourceIdToPluginMap.class).verify();
+    }
+}

--- a/src/test/java/com/teragrep/aer_02/plugin/ResourceIdToPluginMapTest.java
+++ b/src/test/java/com/teragrep/aer_02/plugin/ResourceIdToPluginMapTest.java
@@ -74,10 +74,11 @@ public final class ResourceIdToPluginMapTest {
         );
 
         Map<String, Plugin> plugins = resourceIdToPluginMap.asUnmodifiableMap();
-        Assertions.assertEquals(2, plugins.size());
+        Assertions.assertEquals(1, plugins.size());
         Assertions.assertTrue(plugins.containsKey("123"));
         Assertions.assertEquals(ThrowingPlugin.class.getName(), plugins.get("123").getClass().getName());
-        Assertions.assertEquals(DefaultPlugin.class.getName(), plugins.get("").getClass().getName());
+        Assertions
+                .assertEquals(DefaultPlugin.class.getName(), resourceIdToPluginMap.defaultPlugin().getClass().getName());
     }
 
     @Test
@@ -92,8 +93,9 @@ public final class ResourceIdToPluginMapTest {
         );
 
         Map<String, Plugin> plugins = resourceIdToPluginMap.asUnmodifiableMap();
-        Assertions.assertEquals(1, plugins.size());
-        Assertions.assertEquals(DefaultPlugin.class.getName(), plugins.get("").getClass().getName());
+        Assertions.assertEquals(0, plugins.size());
+        Assertions
+                .assertEquals(DefaultPlugin.class.getName(), resourceIdToPluginMap.defaultPlugin().getClass().getName());
     }
 
     @Test

--- a/src/test/resources/plugincfg.json
+++ b/src/test/resources/plugincfg.json
@@ -1,0 +1,10 @@
+{
+  "defaultPluginFactoryClass": "com.teragrep.aer_02.fakes.ThrowingPluginFactory",
+  "resourceIds": [
+    {
+      "resourceId": "123",
+      "pluginFactoryClass": "com.teragrep.aer_02.plugin.DefaultPluginFactory",
+      "pluginFactoryConfig": "dummy.config"
+    }
+  ]
+}


### PR DESCRIPTION
Integrates the plugin system provided by akv_01 project. Includes default plugin for cases where the resourceId does not match any pluginFactory in config.

Expects `plugins.config.path` environment variable to contain a valid path to a JSON file. Format is described in akv_01 project's README file. If no such variable is provided, the default plugin will be used always.
