### PR TITLE
Update azure-messaging-eventhubs to 5.19.2; close StringReader in JsonRecords

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-messaging-eventhubs</artifactId>
-      <version>5.15.0</version>
+      <version>5.19.2</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.azure.functions</groupId>

--- a/src/main/java/com/teragrep/aer_02/json/JsonRecords.java
+++ b/src/main/java/com/teragrep/aer_02/json/JsonRecords.java
@@ -70,12 +70,14 @@ public final class JsonRecords {
         };
 
         final JsonStructure mainStructure;
-        try (final JsonReader reader = Json.createReader(new StringReader(event))) {
-            mainStructure = reader.read();
-        }
-        catch (JsonParsingException e) {
-            // pass event through as-is if JSON parsing fails
-            return rv;
+        try (final StringReader stringReader = new StringReader(event)) {
+            try (final JsonReader reader = Json.createReader(stringReader)) {
+                mainStructure = reader.read();
+            }
+            catch (JsonParsingException e) {
+                // pass event through as-is if JSON parsing fails
+                return rv;
+            }
         }
 
         if (mainStructure == null || !mainStructure.getValueType().equals(JsonValue.ValueType.OBJECT)) {


### PR DESCRIPTION
Updated library from 5.15.0 to 5.19.2 (azure-messaging-eventhubs)
Add try-with-resources to StringReader in JsonRecords
