### PR TITLE
Integrate nlf_01 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,16 @@
     <sha1></sha1>
   </properties>
   <dependencies>
-    <!-- akv_01 -->
+    <!-- Plugin functionality -->
+    <dependency>
+      <groupId>com.teragrep</groupId>
+      <artifactId>nlf_01</artifactId>
+      <version>2.0.0</version>
+    </dependency>
     <dependency>
       <groupId>com.teragrep</groupId>
       <artifactId>akv_01</artifactId>
-      <version>3.0.0</version>
+      <version>6.0.0</version>
     </dependency>
     <!-- Azure functions -->
     <dependency>

--- a/src/main/java/com/teragrep/aer_02/SyslogBridge.java
+++ b/src/main/java/com/teragrep/aer_02/SyslogBridge.java
@@ -121,12 +121,15 @@ public class SyslogBridge {
             final DefaultOutput defaultOutput = lazyInstance.defaultOutput();
             final Map<String, WrappedPluginFactoryWithConfig> pluginFactories = lazyPluginMapInstance.pluginFactories();
             final WrappedPluginFactoryWithConfig defaultPluginFactory = lazyPluginMapInstance.defaultPluginFactory();
+            final WrappedPluginFactoryWithConfig exceptionPluginFactory = lazyPluginMapInstance
+                    .exceptionPluginFactory();
 
             final EventDataConsumer consumer = new EventDataConsumer(
                     context.getLogger(),
                     defaultOutput,
                     pluginFactories,
                     defaultPluginFactory,
+                    exceptionPluginFactory,
                     lazyInstance.metricRegistry()
             );
             consumer
@@ -147,6 +150,7 @@ public class SyslogBridge {
                 context.getLogger().severe("Exiting because unexpected throwable was caught: <" + t + ">");
             }
             System.exit(1);
+            throw t;
         }
     }
 }

--- a/src/main/java/com/teragrep/aer_02/plugin/LazyPluginMapInstance.java
+++ b/src/main/java/com/teragrep/aer_02/plugin/LazyPluginMapInstance.java
@@ -65,6 +65,7 @@ public final class LazyPluginMapInstance {
 
     private final Map<String, WrappedPluginFactoryWithConfig> pluginFactories;
     private final WrappedPluginFactoryWithConfig defaultPluginFactory;
+    private final WrappedPluginFactoryWithConfig exceptionPluginFactory;
 
     private LazyPluginMapInstance() {
         final Logger logger = Logger.getAnonymousLogger();
@@ -81,9 +82,11 @@ public final class LazyPluginMapInstance {
 
         final Map<String, PluginFactoryConfig> pluginFactoryConfigs = pluginMap.asUnmodifiableMap();
         final String defaultPluginFactoryClassName = pluginMap.defaultPluginFactoryClassName();
+        final String exceptionPluginFactoryClassName = pluginMap.exceptionPluginFactoryClassName();
         final MappedPluginFactories mappedPluginFactories = new MappedPluginFactories(
                 pluginFactoryConfigs,
                 defaultPluginFactoryClassName,
+                exceptionPluginFactoryClassName,
                 hostname,
                 syslogConfig,
                 logger
@@ -91,6 +94,7 @@ public final class LazyPluginMapInstance {
 
         this.pluginFactories = mappedPluginFactories.asUnmodifiableMap();
         this.defaultPluginFactory = mappedPluginFactories.defaultPluginFactoryWithConfig();
+        this.exceptionPluginFactory = mappedPluginFactories.exceptionPluginFactoryWithConfig();
     }
 
     public static LazyPluginMapInstance lazySingletonInstance() {
@@ -110,5 +114,9 @@ public final class LazyPluginMapInstance {
 
     public WrappedPluginFactoryWithConfig defaultPluginFactory() {
         return defaultPluginFactory;
+    }
+
+    public WrappedPluginFactoryWithConfig exceptionPluginFactory() {
+        return exceptionPluginFactory;
     }
 }

--- a/src/main/java/com/teragrep/aer_02/plugin/MappedPluginFactories.java
+++ b/src/main/java/com/teragrep/aer_02/plugin/MappedPluginFactories.java
@@ -60,6 +60,7 @@ public final class MappedPluginFactories {
 
     private final Map<String, PluginFactoryConfig> pluginFactoryConfigs;
     private final String defaultPluginFactoryClassName;
+    private final String exceptionPluginFactoryClassName;
     private final String realHostname;
     private final SyslogConfig syslogConfig;
     private final Logger logger;
@@ -67,12 +68,14 @@ public final class MappedPluginFactories {
     public MappedPluginFactories(
             final Map<String, PluginFactoryConfig> pluginFactoryConfigs,
             final String defaultPluginFactoryClassName,
+            final String exceptionPluginFactoryClassName,
             final String realHostname,
             final SyslogConfig syslogConfig,
             final Logger logger
     ) {
         this.pluginFactoryConfigs = pluginFactoryConfigs;
         this.defaultPluginFactoryClassName = defaultPluginFactoryClassName;
+        this.exceptionPluginFactoryClassName = exceptionPluginFactoryClassName;
         this.realHostname = realHostname;
         this.syslogConfig = syslogConfig;
         this.logger = logger;
@@ -85,9 +88,13 @@ public final class MappedPluginFactories {
     }
 
     public WrappedPluginFactoryWithConfig defaultPluginFactoryWithConfig() {
+        return newWrappedPluginFactoryWithConfig(new PluginFactoryConfigImpl(defaultPluginFactoryClassName, ""));
+    }
+
+    public WrappedPluginFactoryWithConfig exceptionPluginFactoryWithConfig() {
         return newWrappedPluginFactoryWithConfig(
                 new PluginFactoryConfigImpl(
-                        defaultPluginFactoryClassName,
+                        exceptionPluginFactoryClassName,
                         Json.createObjectBuilder().add("realHostname", realHostname).add("syslogHostname", syslogConfig.hostName()).add("syslogAppname", syslogConfig.appName()).build().toString()
                 )
         );
@@ -110,18 +117,22 @@ public final class MappedPluginFactories {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        MappedPluginFactories that = (MappedPluginFactories) o;
+        final MappedPluginFactories that = (MappedPluginFactories) o;
         return Objects.equals(pluginFactoryConfigs, that.pluginFactoryConfigs) && Objects
                 .equals(defaultPluginFactoryClassName, that.defaultPluginFactoryClassName)
-                && Objects.equals(realHostname, that.realHostname) && Objects.equals(syslogConfig, that.syslogConfig);
+                && Objects.equals(exceptionPluginFactoryClassName, that.exceptionPluginFactoryClassName) && Objects.equals(realHostname, that.realHostname) && Objects.equals(syslogConfig, that.syslogConfig);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(pluginFactoryConfigs, defaultPluginFactoryClassName, realHostname, syslogConfig);
+        return Objects
+                .hash(
+                        pluginFactoryConfigs, defaultPluginFactoryClassName, exceptionPluginFactoryClassName,
+                        realHostname, syslogConfig
+                );
     }
 }

--- a/src/main/java/com/teragrep/aer_02/plugin/PluginConfiguration.java
+++ b/src/main/java/com/teragrep/aer_02/plugin/PluginConfiguration.java
@@ -47,6 +47,7 @@ package com.teragrep.aer_02.plugin;
 
 import com.teragrep.aer_02.config.source.Sourceable;
 import com.teragrep.akv_01.json.JsonFile;
+import com.teragrep.nlf_01.NLFPluginFactory;
 import jakarta.json.Json;
 import jakarta.json.JsonStructure;
 import jakarta.json.JsonValue;
@@ -68,7 +69,8 @@ public final class PluginConfiguration {
         if (configPath.isEmpty()) {
             return Json
                     .createObjectBuilder()
-                    .add("defaultPluginFactoryClass", DefaultPluginFactory.class.getName())
+                    .add("defaultPluginFactoryClass", NLFPluginFactory.class.getName())
+                    .add("exceptionPluginFactoryClass", DefaultPluginFactory.class.getName())
                     .add("resourceIds", JsonValue.EMPTY_JSON_ARRAY)
                     .build();
         }

--- a/src/test/java/com/teragrep/aer_02/EventDataConsumerTest.java
+++ b/src/test/java/com/teragrep/aer_02/EventDataConsumerTest.java
@@ -53,6 +53,7 @@ import com.teragrep.aer_02.plugin.WrappedPluginFactoryWithConfig;
 import com.teragrep.akv_01.event.EventImpl;
 import com.teragrep.akv_01.event.ParsedEvent;
 import com.teragrep.akv_01.plugin.PluginFactoryConfigImpl;
+import com.teragrep.nlf_01.NLFPluginFactory;
 import jakarta.json.Json;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -86,6 +87,10 @@ public class EventDataConsumerTest {
                 Logger.getAnonymousLogger(),
                 new OutputFake(),
                 new HashMap<>(),
+                new WrappedPluginFactoryWithConfig(
+                        new NLFPluginFactory(),
+                        new PluginFactoryConfigImpl(NLFPluginFactory.class.getName(), "")
+                ),
                 new WrappedPluginFactoryWithConfig(
                         new DefaultPluginFactory(),
                         new PluginFactoryConfigImpl(

--- a/src/test/java/com/teragrep/aer_02/EventDataConsumerTlsTest.java
+++ b/src/test/java/com/teragrep/aer_02/EventDataConsumerTlsTest.java
@@ -61,6 +61,7 @@ import com.teragrep.net_01.eventloop.EventLoop;
 import com.teragrep.net_01.eventloop.EventLoopFactory;
 import com.teragrep.net_01.server.Server;
 import com.teragrep.net_01.server.ServerFactory;
+import com.teragrep.nlf_01.NLFPluginFactory;
 import com.teragrep.rlo_06.RFC5424Frame;
 import com.teragrep.rlp_01.SSLContextFactory;
 import com.teragrep.rlp_01.client.SSLContextSupplier;
@@ -191,6 +192,10 @@ public class EventDataConsumerTlsTest {
                 Logger.getAnonymousLogger(),
                 output,
                 new HashMap<>(),
+                new WrappedPluginFactoryWithConfig(
+                        new NLFPluginFactory(),
+                        new PluginFactoryConfigImpl(NLFPluginFactory.class.getName(), "")
+                ),
                 new WrappedPluginFactoryWithConfig(
                         new DefaultPluginFactory(),
                         new PluginFactoryConfigImpl(

--- a/src/test/java/com/teragrep/aer_02/SyslogBridgeTest.java
+++ b/src/test/java/com/teragrep/aer_02/SyslogBridgeTest.java
@@ -157,13 +157,19 @@ public final class SyslogBridgeTest {
 
     @Test
     void testSyslogBridgeWithJsonRecordsData() {
+        // This should use the NLFPlugin
         PartitionContextFake pcf = new PartitionContextFake("eventhub.123", "test1", "$Default", "0");
         Map<String, Object> props = new HashMap<>();
         final SyslogBridge bridge = new SyslogBridge();
 
         final String jsonRecords = Json
                 .createObjectBuilder()
-                .add("records", Json.createArrayBuilder().add("record1").add("record2").add("record3").build())
+                .add(
+                        "records",
+                        Json
+                                .createArrayBuilder()
+                                .add(Json.createObjectBuilder().add("TimeGenerated", "2020-01-01T00:00:00.000Z").add("_ResourceId", "/1/2/3/4/5/6/7/8").add("AppRoleName", "app-role-name")).add(Json.createObjectBuilder().add("TimeGenerated", "2021-01-01T00:00:00.000Z").add("_ResourceId", "/1/2/3/4/5/6/7/8").add("AppRoleName", "app-role-name")).add(Json.createObjectBuilder().add("TimeGenerated", "2022-01-01T00:00:00.000Z").add("_ResourceId", "/1/2/3/4/5/6/7/8").add("AppRoleName", "app-role-name")).build()
+                )
                 .build()
                 .toString();
 
@@ -185,15 +191,15 @@ public final class SyslogBridgeTest {
         };
 
         final String[] expectedMessages = new String[] {
-                "\"record1\"",
-                "\"record2\"",
-                "\"record3\"",
-                "\"record1\"",
-                "\"record2\"",
-                "\"record3\"",
-                "\"record1\"",
-                "\"record2\"",
-                "\"record3\""
+                "{\"TimeGenerated\":\"2020-01-01T00:00:00.000Z\",\"_ResourceId\":\"/1/2/3/4/5/6/7/8\",\"AppRoleName\":\"app-role-name\"}",
+                "{\"TimeGenerated\":\"2021-01-01T00:00:00.000Z\",\"_ResourceId\":\"/1/2/3/4/5/6/7/8\",\"AppRoleName\":\"app-role-name\"}",
+                "{\"TimeGenerated\":\"2022-01-01T00:00:00.000Z\",\"_ResourceId\":\"/1/2/3/4/5/6/7/8\",\"AppRoleName\":\"app-role-name\"}",
+                "{\"TimeGenerated\":\"2020-01-01T00:00:00.000Z\",\"_ResourceId\":\"/1/2/3/4/5/6/7/8\",\"AppRoleName\":\"app-role-name\"}",
+                "{\"TimeGenerated\":\"2021-01-01T00:00:00.000Z\",\"_ResourceId\":\"/1/2/3/4/5/6/7/8\",\"AppRoleName\":\"app-role-name\"}",
+                "{\"TimeGenerated\":\"2022-01-01T00:00:00.000Z\",\"_ResourceId\":\"/1/2/3/4/5/6/7/8\",\"AppRoleName\":\"app-role-name\"}",
+                "{\"TimeGenerated\":\"2020-01-01T00:00:00.000Z\",\"_ResourceId\":\"/1/2/3/4/5/6/7/8\",\"AppRoleName\":\"app-role-name\"}",
+                "{\"TimeGenerated\":\"2021-01-01T00:00:00.000Z\",\"_ResourceId\":\"/1/2/3/4/5/6/7/8\",\"AppRoleName\":\"app-role-name\"}",
+                "{\"TimeGenerated\":\"2022-01-01T00:00:00.000Z\",\"_ResourceId\":\"/1/2/3/4/5/6/7/8\",\"AppRoleName\":\"app-role-name\"}"
         };
 
         int loops = 0;
@@ -202,8 +208,8 @@ public final class SyslogBridgeTest {
             frame.load(new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8)));
             Assertions.assertTrue(Assertions.assertDoesNotThrow(frame::next));
             Assertions.assertEquals(expectedMessages[loops], frame.msg.toString());
-            Assertions.assertEquals("localhost.localdomain", frame.hostname.toString());
-            Assertions.assertEquals("aer-02", frame.appName.toString());
+            Assertions.assertEquals("md5-6f401cfe0a539a619fa9c17798d199258", frame.hostname.toString());
+            Assertions.assertEquals("app-role-name", frame.appName.toString());
             Assertions.assertEquals(expectedSeqNums[loops], frame.msgId.toString());
             loops++;
         }

--- a/src/test/java/com/teragrep/aer_02/plugin/MappedPluginFactoriesTest.java
+++ b/src/test/java/com/teragrep/aer_02/plugin/MappedPluginFactoriesTest.java
@@ -50,6 +50,7 @@ import com.teragrep.aer_02.config.SyslogConfig;
 import com.teragrep.aer_02.fakes.ThrowingPluginFactory;
 import com.teragrep.akv_01.plugin.PluginFactoryConfig;
 import com.teragrep.akv_01.plugin.PluginFactoryConfigImpl;
+import com.teragrep.nlf_01.NLFPluginFactory;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -67,7 +68,8 @@ public final class MappedPluginFactoriesTest {
 
         final MappedPluginFactories mappedPluginFactories = new MappedPluginFactories(
                 configs,
-                "com.teragrep.aer_02.plugin.DefaultPluginFactory",
+                NLFPluginFactory.class.getName(),
+                DefaultPluginFactory.class.getName(),
                 "host",
                 new SyslogConfig("app", "host"),
                 Logger.getAnonymousLogger()
@@ -80,8 +82,14 @@ public final class MappedPluginFactoriesTest {
                 .assertEquals(ThrowingPluginFactory.class.getName(), plugins.get("123").pluginFactory().getClass().getName());
         Assertions
                 .assertEquals(
-                        DefaultPluginFactory.class.getName(),
+                        NLFPluginFactory.class.getName(),
                         mappedPluginFactories.defaultPluginFactoryWithConfig().pluginFactory().getClass().getName()
+                );
+
+        Assertions
+                .assertEquals(
+                        DefaultPluginFactory.class.getName(),
+                        mappedPluginFactories.exceptionPluginFactoryWithConfig().pluginFactory().getClass().getName()
                 );
     }
 
@@ -90,7 +98,8 @@ public final class MappedPluginFactoriesTest {
         final Map<String, PluginFactoryConfig> configs = new HashMap<>();
         final MappedPluginFactories mappedPluginFactories = new MappedPluginFactories(
                 configs,
-                "com.teragrep.aer_02.plugin.DefaultPluginFactory",
+                NLFPluginFactory.class.getName(),
+                DefaultPluginFactory.class.getName(),
                 "host",
                 new SyslogConfig("app", "host"),
                 Logger.getAnonymousLogger()
@@ -100,8 +109,14 @@ public final class MappedPluginFactoriesTest {
         Assertions.assertEquals(0, plugins.size());
         Assertions
                 .assertEquals(
-                        DefaultPluginFactory.class.getName(),
+                        NLFPluginFactory.class.getName(),
                         mappedPluginFactories.defaultPluginFactoryWithConfig().pluginFactory().getClass().getName()
+                );
+
+        Assertions
+                .assertEquals(
+                        DefaultPluginFactory.class.getName(),
+                        mappedPluginFactories.exceptionPluginFactoryWithConfig().pluginFactory().getClass().getName()
                 );
     }
 
@@ -112,6 +127,7 @@ public final class MappedPluginFactoriesTest {
         final MappedPluginFactories mappedPluginFactories = new MappedPluginFactories(
                 configs,
                 "invalid",
+                "invalid2",
                 "host",
                 new SyslogConfig("app", "host"),
                 Logger.getAnonymousLogger()
@@ -119,6 +135,7 @@ public final class MappedPluginFactoriesTest {
 
         Assertions.assertThrows(IllegalStateException.class, mappedPluginFactories::asUnmodifiableMap);
         Assertions.assertThrows(IllegalStateException.class, mappedPluginFactories::defaultPluginFactoryWithConfig);
+        Assertions.assertThrows(IllegalStateException.class, mappedPluginFactories::exceptionPluginFactoryWithConfig);
     }
 
     @Test
@@ -128,6 +145,7 @@ public final class MappedPluginFactoriesTest {
         final MappedPluginFactories mappedPluginFactories = new MappedPluginFactories(
                 configs,
                 SyslogBridge.class.getName(),
+                SyslogBridge.class.getName(),
                 "host",
                 new SyslogConfig("app", "host"),
                 Logger.getAnonymousLogger()
@@ -135,6 +153,7 @@ public final class MappedPluginFactoriesTest {
 
         Assertions.assertThrows(ClassCastException.class, mappedPluginFactories::asUnmodifiableMap);
         Assertions.assertThrows(ClassCastException.class, mappedPluginFactories::defaultPluginFactoryWithConfig);
+        Assertions.assertThrows(ClassCastException.class, mappedPluginFactories::exceptionPluginFactoryWithConfig);
     }
 
     @Test

--- a/src/test/java/com/teragrep/aer_02/plugin/PluginConfigurationTest.java
+++ b/src/test/java/com/teragrep/aer_02/plugin/PluginConfigurationTest.java
@@ -46,6 +46,7 @@
 package com.teragrep.aer_02.plugin;
 
 import com.teragrep.aer_02.fakes.SourceableFake;
+import com.teragrep.nlf_01.NLFPluginFactory;
 import jakarta.json.JsonStructure;
 import jakarta.json.stream.JsonParsingException;
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -65,10 +66,7 @@ public final class PluginConfigurationTest {
 
         // Should default to com.teragrep.aer_02.plugin.DefaultPluginFactory
         Assertions
-                .assertEquals(
-                        "com.teragrep.aer_02.plugin.DefaultPluginFactory",
-                        js.asJsonObject().getString("defaultPluginFactoryClass")
-                );
+                .assertEquals(NLFPluginFactory.class.getName(), js.asJsonObject().getString("defaultPluginFactoryClass"));
     }
 
     @Test

--- a/src/test/resources/plugincfg.json
+++ b/src/test/resources/plugincfg.json
@@ -1,5 +1,6 @@
 {
   "defaultPluginFactoryClass": "com.teragrep.aer_02.fakes.ThrowingPluginFactory",
+  "exceptionPluginFactoryClass": "",
   "resourceIds": [
     {
       "resourceId": "123",


### PR DESCRIPTION
Introduces nlf_01 version 2.0.0; by default uses NLFPlugin, and if PluginException is thrown , the old DefaultPlugin will be used instead.

akv_01 dependency was updated to 6.0.0.