### PR TITLE
Update deprecated GH Actions cache@v2 to cache@v4

### DIFF
--- a/.github/workflows/upload_github_release.yaml
+++ b/.github/workflows/upload_github_release.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Cache Local Maven Repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/upload_maven_release.yaml
+++ b/.github/workflows/upload_maven_release.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Cache Local Maven Repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
- Deprecation notice: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down