### PR TITLE
Remove the unused Logger from EventDataConsumer

### DIFF
--- a/src/main/java/com/teragrep/aer_02/EventDataConsumer.java
+++ b/src/main/java/com/teragrep/aer_02/EventDataConsumer.java
@@ -61,7 +61,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -69,7 +68,6 @@ import static com.codahale.metrics.MetricRegistry.name;
 final class EventDataConsumer {
 
     // Note: Checkpointing is handled automatically.
-    private final Logger logger;
     private final Output output;
     private final Map<String, WrappedPluginFactoryWithConfig> pluginFactories;
     private final MetricRegistry metricRegistry;
@@ -77,14 +75,12 @@ final class EventDataConsumer {
     private final WrappedPluginFactoryWithConfig exceptionPluginFactory;
 
     EventDataConsumer(
-            final Logger logger,
             final Output output,
             final Map<String, WrappedPluginFactoryWithConfig> pluginFactories,
             final WrappedPluginFactoryWithConfig defaultPluginFactory,
             final WrappedPluginFactoryWithConfig exceptionPluginFactory,
             final MetricRegistry metricRegistry
     ) {
-        this.logger = logger;
         this.metricRegistry = metricRegistry;
         this.pluginFactories = pluginFactories;
         this.exceptionPluginFactory = exceptionPluginFactory;

--- a/src/main/java/com/teragrep/aer_02/SyslogBridge.java
+++ b/src/main/java/com/teragrep/aer_02/SyslogBridge.java
@@ -125,7 +125,6 @@ public class SyslogBridge {
                     .exceptionPluginFactory();
 
             final EventDataConsumer consumer = new EventDataConsumer(
-                    context.getLogger(),
                     defaultOutput,
                     pluginFactories,
                     defaultPluginFactory,

--- a/src/test/java/com/teragrep/aer_02/EventDataConsumerTest.java
+++ b/src/test/java/com/teragrep/aer_02/EventDataConsumerTest.java
@@ -71,7 +71,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
@@ -90,7 +89,6 @@ public class EventDataConsumerTest {
         systemProps.put("SequenceNumber", "1");
         MetricRegistry metricRegistry = new MetricRegistry();
         EventDataConsumer eventDataConsumer = new EventDataConsumer(
-                Logger.getAnonymousLogger(),
                 new OutputFake(),
                 new HashMap<>(),
                 new WrappedPluginFactoryWithConfig(

--- a/src/test/java/com/teragrep/aer_02/EventDataConsumerTlsTest.java
+++ b/src/test/java/com/teragrep/aer_02/EventDataConsumerTlsTest.java
@@ -195,7 +195,6 @@ public class EventDataConsumerTlsTest {
         );
 
         final EventDataConsumer edc = new EventDataConsumer(
-                Logger.getAnonymousLogger(),
                 output,
                 new HashMap<>(),
                 new WrappedPluginFactoryWithConfig(


### PR DESCRIPTION
## Description

<!-- Please include a summary of changes made in your pull request. -->
This PR removes the Logger that is initialized & required for EventDataConsumer.

This PR does not change the logic, and shouldn't affect the logging since the Logger was not used.

Closes #100
<!-- If you can't fill all check boxes in Checklists section, please explain why. -->

## Checklists

<!-- Fill check boxes before submitting the pull request. -->

### Testing

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods. 

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [x] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Object Quality.
- [x] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.  
